### PR TITLE
Fix missing ";" in Handshake.idl

### DIFF
--- a/src/main/idl/Handshake.idl
+++ b/src/main/idl/Handshake.idl
@@ -75,7 +75,7 @@ module robotDataLogger{
     {
         sequence<string, 64> fieldNames;
         sequence<string, 64> fieldValues;
-    }
+    };
 
 	struct ReferenceFrameInformation
 	{


### PR DESCRIPTION
This PR fixes a missing semicolon in the handshake.idl file