### PR TITLE
Lock file Optional when running logger

### DIFF
--- a/src/main/java/us/ihmc/publisher/logger/LoggerDeployConfiguration.java
+++ b/src/main/java/us/ihmc/publisher/logger/LoggerDeployConfiguration.java
@@ -23,7 +23,8 @@ public class LoggerDeployConfiguration
          deploy.addVariable("RESTART_LOGGER", restartonSave ? "true" : "false");
          deploy.addTextFile("CAMERA_SETTINGS", "CameraSettings.yaml", CameraSettingsLoader.toString(settings), getCameraSettingsFile(remote), false);
          deploy.addTextFile("STATIC_HOST_LIST", "ControllerHosts.yaml", StaticHostListLoader.toString(staticHostList), getHostsFile(remote), false);
-         deploy.deploy("if ${RESTART_LOGGER}; then sudo /bin/systemctl restart ihmc-logger.service; echo \"Restarted logger\"; else echo \"Skipped logger restart\"; fi");
+         deploy.deploy(
+               "if ${RESTART_LOGGER}; then sudo /bin/systemctl restart ihmc-logger.service; echo \"Restarted logger\"; else echo \"Skipped logger restart\"; fi");
       }
       catch (IOException e)
       {
@@ -57,19 +58,25 @@ public class LoggerDeployConfiguration
       return StaticHostListLoader.loadHostList(data);
    }
 
-   public static void deploy(SSHRemote remote, String dist, boolean restartNightly, FXConsole deployConsole, boolean logger_service)
+   public static void deploy(SSHRemote remote,
+                             String dist,
+                             boolean restartNightly,
+                             FXConsole deployConsole,
+                             boolean logger_service,
+                             boolean deploy_with_lock_file)
    {
       SSHDeploy deploy = new SSHDeploy(remote, deployConsole);
       URL deployScript = loader.getResource("deploy.sh");
       URL loggerService = loader.getResource("ihmc-logger.service");
       URL crontab = loader.getResource("ihmc-logger-cron");
-      
+
       deploy.addBinaryFile("DIST", dist, "/tmp/logger.tar", false);
       deploy.addTextFile("LOGGER_SERVICE", "ihmc-logger.service", loggerService, "/etc/systemd/system/ihmc-logger.service", true);
       deploy.addTextFile("CRON_ENTRY", "ihmc-logger-cron", crontab, "/tmp/ihmc-logger-cron", true);
-      
+
       deploy.addVariable("NIGHTLY_RESTART", restartNightly ? "true" : "false");
       deploy.addVariable("DEPLOY_SERVICE", logger_service ? "true" : "false");
+      deploy.addVariable("DEPLOY_WITH_LOCK_FILE", deploy_with_lock_file ? "true" : "false");
 
       deploy.deploy(deployScript);
    }

--- a/src/main/java/us/ihmc/publisher/logger/ui/LoggerDeployController.java
+++ b/src/main/java/us/ihmc/publisher/logger/ui/LoggerDeployController.java
@@ -100,6 +100,9 @@ public class LoggerDeployController implements Initializable
 
    @FXML
    CheckBox logger_service;
+
+   @FXML
+   CheckBox deploy_with_lock_file;
    
 
    @Override
@@ -119,6 +122,8 @@ public class LoggerDeployController implements Initializable
       prefs.linkToPrefs(restart_on_save, true);
 
       prefs.linkToPrefs(logger_service, true);
+
+      prefs.linkToPrefs(deploy_with_lock_file, true);
 
       camera_table.setEditable(true);
 
@@ -359,7 +364,8 @@ public class LoggerDeployController implements Initializable
                                    logger_dist.getText(),
                                    logger_restart_midnight.isSelected(),
                                    getStage(),
-                                   logger_service.isSelected());
+                                   logger_service.isSelected(),
+                                   deploy_with_lock_file.isSelected());
    }
 
    private Stage getStage()

--- a/src/main/java/us/ihmc/publisher/logger/ui/LoggerDeployScript.java
+++ b/src/main/java/us/ihmc/publisher/logger/ui/LoggerDeployScript.java
@@ -12,8 +12,8 @@ import us.ihmc.robotDataLogger.StaticHostList;
 public interface LoggerDeployScript
 {
    /**
-    * Called when clicking "Deploy logger" in the application 
-    * 
+    * Called when clicking "Deploy logger" in the application
+    *
     * @param logger_host
     * @param logger_user
     * @param logger_password
@@ -30,11 +30,12 @@ public interface LoggerDeployScript
                        String logger_dist,
                        boolean nightly_restart,
                        Stage stage,
-                       boolean logger_service)
+                       boolean logger_service,
+                       boolean deploy_with_lock_file)
    {
       FXConsole deployConsole = new FXConsole(stage);
       SSHRemote remote = new SSHRemote(logger_host, logger_user, logger_password, logger_sudo_password);
-      LoggerDeployConfiguration.deploy(remote, logger_dist, nightly_restart, deployConsole, logger_service);
+      LoggerDeployConfiguration.deploy(remote, logger_dist, nightly_restart, deployConsole, logger_service, deploy_with_lock_file);
    }
 
    default boolean implementsAutoRestart()
@@ -53,27 +54,21 @@ public interface LoggerDeployScript
    {
       FXConsole deployConsole = new FXConsole(stage);
       SSHRemote remote = new SSHRemote(logger_host, logger_user, logger_password, logger_sudo_password);
-      
+
       LoggerDeployConfiguration.saveConfiguration(remote, settings, staticHostList, restartonSave, deployConsole);
    }
-   
-   default CameraSettings loadCameraConfiguration(String logger_host,
-                                  String logger_user,
-                                  String logger_password,
-                                  String logger_sudo_password,
-                                  Stage stage) throws IOException
+
+   default CameraSettings loadCameraConfiguration(String logger_host, String logger_user, String logger_password, String logger_sudo_password, Stage stage)
+         throws IOException
    {
-      SSHRemote remote = new SSHRemote(logger_host, logger_user, logger_password, logger_sudo_password);      
+      SSHRemote remote = new SSHRemote(logger_host, logger_user, logger_password, logger_sudo_password);
       return LoggerDeployConfiguration.loadCameraConfiguration(remote);
    }
-   
-   default StaticHostList loadStaticHostList(String logger_host,
-                                                  String logger_user,
-                                                  String logger_password,
-                                                  String logger_sudo_password,
-                                                  Stage stage) throws IOException
+
+   default StaticHostList loadStaticHostList(String logger_host, String logger_user, String logger_password, String logger_sudo_password, Stage stage)
+         throws IOException
    {
-      SSHRemote remote = new SSHRemote(logger_host, logger_user, logger_password, logger_sudo_password);      
+      SSHRemote remote = new SSHRemote(logger_host, logger_user, logger_password, logger_sudo_password);
       return LoggerDeployConfiguration.loadStaticHostList(remote);
    }
 }

--- a/src/main/java/us/ihmc/robotDataLogger/logger/YoVariableLoggerOptions.java
+++ b/src/main/java/us/ihmc/robotDataLogger/logger/YoVariableLoggerOptions.java
@@ -12,6 +12,7 @@ import us.ihmc.javadecklink.Capture.CodecID;
 
 public class YoVariableLoggerOptions
 {
+   private static boolean deployWithLockFile = true;
    public final static String defaultLogDirectory = System.getProperty("user.home") + "/robotLogs";
 
    public final static CodecID defaultCodec = CodecID.AV_CODEC_ID_MJPEG;
@@ -39,46 +40,53 @@ public class YoVariableLoggerOptions
       SimpleJSAP jsap = new SimpleJSAP("YoVariabeLogger",
                                        "Logs YoVariables and video from a robot",
                                        new Parameter[] {new Switch("disableVideo", 'n', "noVideo", "Disable video recording"),
-                                             new FlaggedOption("logDirectory",
-                                                               JSAP.STRING_PARSER,
-                                                               YoVariableLoggerOptions.defaultLogDirectory,
-                                                               JSAP.NOT_REQUIRED,
-                                                               'd',
-                                                               "directory",
-                                                               "Directory where to save log files"),
-                                             new FlaggedOption("videoQuality",
-                                                               JSAP.DOUBLE_PARSER,
-                                                               String.valueOf(YoVariableLoggerOptions.defaultVideoQuality),
-                                                               JSAP.NOT_REQUIRED,
-                                                               'q',
-                                                               "quality",
-                                                               "Video quality for MJPEG"),
-                                             new FlaggedOption("videoCodec",
-                                                               JSAP.STRING_PARSER,
-                                                               String.valueOf(defaultCodec),
-                                                               JSAP.NOT_REQUIRED,
-                                                               'c',
-                                                               "codec",
-                                                               "Desired video codec. AV_CODEC_ID_H264 or AV_CODEC_ID_MJPEG"),
-                                             new FlaggedOption("crf",
-                                                               JSAP.INTEGER_PARSER,
-                                                               String.valueOf(defaultCRF),
-                                                               JSAP.NOT_REQUIRED,
-                                                               'r',
-                                                               "crf",
-                                                               "CRF (Constant rate factor) for H264. 0-51, 0 is lossless. Sane values are 18 to 28."),
-                                             new FlaggedOption("rotate",
-                                                               JSAP.INTEGER_PARSER,
-                                                               "0",
-                                                               JSAP.NOT_REQUIRED,
-                                                               'o',
-                                                               "rotate",
-                                                               "Rotate logs in incoming folder, keep n logs. Set to zero to keep all logs."),
-                                             new Switch("flushAggressivelyToDisk",
-                                                        's',
-                                                        "sync",
-                                                        "Aggressively flush data to disk. Reduces change of data loss but doesn't work on slow platters."),
-                                             new Switch("disableAutoDiscovery", 'a', "noDiscovery", "Disable autodiscovery of clients.")});
+                                                        new FlaggedOption("deployWithoutLockFile",
+                                                                          JSAP.BOOLEAN_PARSER,
+                                                                          String.valueOf(YoVariableLoggerOptions.deployWithLockFile),
+                                                                          JSAP.NOT_REQUIRED,
+                                                                          'l',
+                                                                          "lockFile",
+                                                                          "Deploy with lock file"),
+                                                        new FlaggedOption("logDirectory",
+                                                                          JSAP.STRING_PARSER,
+                                                                          YoVariableLoggerOptions.defaultLogDirectory,
+                                                                          JSAP.NOT_REQUIRED,
+                                                                          'd',
+                                                                          "directory",
+                                                                          "Directory where to save log files"),
+                                                        new FlaggedOption("videoQuality",
+                                                                          JSAP.DOUBLE_PARSER,
+                                                                          String.valueOf(YoVariableLoggerOptions.defaultVideoQuality),
+                                                                          JSAP.NOT_REQUIRED,
+                                                                          'q',
+                                                                          "quality",
+                                                                          "Video quality for MJPEG"),
+                                                        new FlaggedOption("videoCodec",
+                                                                          JSAP.STRING_PARSER,
+                                                                          String.valueOf(defaultCodec),
+                                                                          JSAP.NOT_REQUIRED,
+                                                                          'c',
+                                                                          "codec",
+                                                                          "Desired video codec. AV_CODEC_ID_H264 or AV_CODEC_ID_MJPEG"),
+                                                        new FlaggedOption("crf",
+                                                                          JSAP.INTEGER_PARSER,
+                                                                          String.valueOf(defaultCRF),
+                                                                          JSAP.NOT_REQUIRED,
+                                                                          'r',
+                                                                          "crf",
+                                                                          "CRF (Constant rate factor) for H264. 0-51, 0 is lossless. Sane values are 18 to 28."),
+                                                        new FlaggedOption("rotate",
+                                                                          JSAP.INTEGER_PARSER,
+                                                                          "0",
+                                                                          JSAP.NOT_REQUIRED,
+                                                                          'o',
+                                                                          "rotate",
+                                                                          "Rotate logs in incoming folder, keep n logs. Set to zero to keep all logs."),
+                                                        new Switch("flushAggressivelyToDisk",
+                                                                   's',
+                                                                   "sync",
+                                                                   "Aggressively flush data to disk. Reduces change of data loss but doesn't work on slow platters."),
+                                                        new Switch("disableAutoDiscovery", 'a', "noDiscovery", "Disable autodiscovery of clients.")});
       JSAPResult config = jsap.parse(args);
       if (jsap.messagePrinted())
       {
@@ -88,6 +96,7 @@ public class YoVariableLoggerOptions
       }
 
       YoVariableLoggerOptions options = new YoVariableLoggerOptions();
+      options.setDeployWithLockFile(config.getBoolean("deployWithoutLockFile"));
       options.setLogDirectory(config.getString("logDirectory"));
       options.setVideoQuality(config.getDouble("videoQuality"));
       options.setDisableVideo(config.getBoolean("disableVideo"));
@@ -195,4 +204,13 @@ public class YoVariableLoggerOptions
       this.disableAutoDiscovery = disableAutoDiscovery;
    }
 
+   public void setDeployWithLockFile(boolean deployWithoutLockFile)
+   {
+      YoVariableLoggerOptions.deployWithLockFile = deployWithoutLockFile;
+   }
+
+   public boolean getDeployWithLockFile()
+   {
+      return deployWithLockFile;
+   }
 }

--- a/src/main/resources/us/ihmc/publisher/logger/ihmc-logger-cron
+++ b/src/main/resources/us/ihmc/publisher/logger/ihmc-logger-cron
@@ -1,3 +1,3 @@
 # /etc/cron.d/ihmc-logger-cron Restarts the ihmc-logger service nightly
 
-0 3 * * *	root	/bin/systemctl restart ihmc-logger
+0 3 * * *	root	/bin/systemctl restart ihmc-logger -l ${DEPLOY_WITH_LOCK_FILE}

--- a/src/main/resources/us/ihmc/publisher/logger/ihmc-logger.service
+++ b/src/main/resources/us/ihmc/publisher/logger/ihmc-logger.service
@@ -4,7 +4,7 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-ExecStart=/opt/ihmc/logger/bin/IHMCLogger
+ExecStart=/opt/ihmc/logger/bin/IHMCLogger -l ${DEPLOY_WITH_LOCK_FILE}
 User=${USER}
 Group=${USER}
 Restart=always

--- a/src/main/resources/us/ihmc/publisher/logger/ui/LoggerSetup.fxml
+++ b/src/main/resources/us/ihmc/publisher/logger/ui/LoggerSetup.fxml
@@ -84,9 +84,10 @@
                   <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
               </columnConstraints>
               <rowConstraints>
-                <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                  <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                <RowConstraints minHeight="10.0" prefHeight="25.0" vgrow="SOMETIMES" />
+                <RowConstraints minHeight="10.0" prefHeight="25.0" vgrow="SOMETIMES" />
+                <RowConstraints minHeight="10.0" prefHeight="25.0" vgrow="SOMETIMES" />
+                <RowConstraints minHeight="10.0" prefHeight="25.0" vgrow="SOMETIMES" />
               </rowConstraints>
                <children>
                   <Label text="Logger distribution" />
@@ -94,9 +95,11 @@
                   <Button fx:id="browse_dist" mnemonicParsing="false" text="Browse..." GridPane.columnIndex="2" />
                    <Label fx:id="restart_label" text="Restart daily" GridPane.rowIndex="1" />
                    <Label text="Deploy Service" GridPane.rowIndex="2" />
+                   <Label text="Deploy with Lock File" GridPane.rowIndex="3" />
                   <CheckBox fx:id="logger_restart_midnight" mnemonicParsing="false" GridPane.columnIndex="1" GridPane.rowIndex="1" />
                   <CheckBox fx:id="logger_service" mnemonicParsing="false" GridPane.columnIndex="1" GridPane.rowIndex="2" />
-                  <Button mnemonicParsing="false" onAction="#logger_deploy" text="Deploy logger " GridPane.rowIndex="3" />
+                   <CheckBox fx:id="deploy_with_lock_file" mnemonicParsing="false" GridPane.columnIndex="1" GridPane.rowIndex="3" />
+                  <Button mnemonicParsing="false" onAction="#logger_deploy" text="Deploy logger " GridPane.rowIndex="4" />
                </children>
             </GridPane>
          </content>


### PR DESCRIPTION
Added the option to make the lock file creation optional, it can be configured via the deploy gui, a checkbox has been added, by default it is true

Edge cases tested:
- Running `YoVariableLoggerDispatcher` without any command line configuration
- Running `YoVariableLoggerDispatcher` with the new command line argument
- Deploying with the boolean as true and false, worked for both
- When boolean is false was able to run multiple loggers, good!