### PR TITLE
Added feature to shutdown the logger properly if the server crashes unexpectedly

### DIFF
--- a/src/main/java/us/ihmc/robotDataLogger/logger/YoVariableLoggerListener.java
+++ b/src/main/java/us/ihmc/robotDataLogger/logger/YoVariableLoggerListener.java
@@ -88,6 +88,7 @@ public class YoVariableLoggerListener implements YoVariablesUpdatedListener
 
    private long lastReceivedTimestamp = Long.MIN_VALUE;
    private long ticksWithoutNewTimestamp = 0;
+   private boolean alreadyShutDown = false;
 
    private final Announcement request;
    private final Consumer<Announcement> doneListener;
@@ -440,6 +441,11 @@ public class YoVariableLoggerListener implements YoVariablesUpdatedListener
 
          doneListener.accept(request);
       }
+
+      if (alreadyShutDown)
+      {
+         LogTools.info("This may have already shutdown properly due to the server losing power for an extended amount of time");
+      }
    }
 
    private final ExecutorService executor = Executors.newCachedThreadPool();
@@ -575,6 +581,7 @@ public class YoVariableLoggerListener implements YoVariablesUpdatedListener
          {
             LogTools.warn("Whoa whoa whoa, haven't received new timestamps in a while, maybe the server crashed without proper shutdown, stopping the logger...");
             disconnected();
+            alreadyShutDown = true;
          }
 
          if (timestamp > lastReceivedTimestamp) // Check if this a newer timestamp. UDP is out of order and the TCP packets also call this function

--- a/src/main/java/us/ihmc/robotDataLogger/logger/YoVariableLoggerListener.java
+++ b/src/main/java/us/ihmc/robotDataLogger/logger/YoVariableLoggerListener.java
@@ -444,7 +444,7 @@ public class YoVariableLoggerListener implements YoVariablesUpdatedListener
 
       if (alreadyShutDown)
       {
-         LogTools.info("This may have already shutdown properly due to the server losing power for an extended amount of time");
+         LogTools.info("This may have already shutdown because the connection to the server was lost");
       }
    }
 
@@ -577,7 +577,7 @@ public class YoVariableLoggerListener implements YoVariablesUpdatedListener
       synchronized (timestampUpdater)
       {
          // We haven't received any new timestamps, shutdown the logger gracefully
-         if (ticksWithoutNewTimestamp == TICKS_WITHOUT_DATA_BEFORE_SHUTDOWN)
+         if (!alreadyShutDown && ticksWithoutNewTimestamp == TICKS_WITHOUT_DATA_BEFORE_SHUTDOWN)
          {
             LogTools.warn("Whoa whoa whoa, haven't received new timestamps in a while, maybe the server crashed without proper shutdown, stopping the logger...");
             disconnected();


### PR DESCRIPTION
We need to get a certain amount of ticks in a row without a new timestamp, then we shutdown.
This is because if power is lost to the server the JVM doesn't shutdown properly, therefore we can keep logging useless data, this prevents that.