### PR TITLE
Fixed exception by adding check to make sure the elements exist

### DIFF
--- a/src/main/java/us/ihmc/robotDataLogger/util/SocketUtils.java
+++ b/src/main/java/us/ihmc/robotDataLogger/util/SocketUtils.java
@@ -4,6 +4,7 @@ import java.net.BindException;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
+import java.util.Enumeration;
 
 public final class SocketUtils
 {
@@ -18,16 +19,19 @@ public final class SocketUtils
    {
       try
       {
-         InetAddress address = networkInterface.getInetAddresses().nextElement();
-         while (address.isLoopbackAddress() && networkInterface.getInetAddresses().hasMoreElements())
-         {
-            address = networkInterface.getInetAddresses().nextElement();
-         }
+         Enumeration<InetAddress> address = networkInterface.getInetAddresses();
 
-         DatagramSocket socket = new DatagramSocket(port, address);
-         socket.close();
-         socket.disconnect();
-         return false;
+         while(address.hasMoreElements())
+         {
+            InetAddress inetAddress = address.nextElement();
+            if (!inetAddress.isLoopbackAddress())
+            {
+               DatagramSocket socket = new DatagramSocket(port, inetAddress);
+               socket.close();
+               socket.disconnect();
+               return false;
+            }
+         }
       }
       catch (BindException e)
       {
@@ -38,5 +42,7 @@ public final class SocketUtils
          e.printStackTrace();
          return true; // Other errors
       }
+
+      return true; // Other errors
    }
 }


### PR DESCRIPTION
Used to get this exception on my machine:

`java.util.NoSuchElementException
	at java.base/java.net.NetworkInterface$1.nextElement(NetworkInterface.java:417)
	at us.ihmc.robotDataLogger.util.SocketUtils.isUDPPortInUse(SocketUtils.java:21)
	at us.ihmc.robotDataLogger.websocket.DataServerLocationBroadcast.getSocketChannelList(DataServerLocationBroadcast.java:89)
	at us.ihmc.robotDataLogger.websocket.client.discovery.DataServerLocationBroadcastReceiver.<init>(DataServerLocationBroadcastReceiver.java:34)
	at us.ihmc.robotDataLogger.websocket.client.discovery.DataServerDiscoveryClient.<init>(DataServerDiscoveryClient.java:56)
	at us.ihmc.scs2.sessionVisualizer.jfx.session.remote.RemoteSessionManagerController.initialize(RemoteSessionManagerController.java:167)
	at us.ihmc.scs2.sessionVisualizer.jfx.managers.MultiSessionManager.openSessionControls(MultiSessionManager.java:215)
	at us.ihmc.scs2.sessionVisualizer.jfx.managers.MultiSessionManager.openSessionControls(MultiSessionManager.java:186)
	at us.ihmc.scs2.sessionVisualizer.jfx.managers.MultiSessionManager.lambda$new$4(MultiSessionManager.java:114)
	at us.ihmc.messager.TopicListener.receivedMessageForTopic(TopicListener.java:20)
	at us.ihmc.messager.javafx.SharedMemoryJavaFXMessager$JavaFXTopicListeners.lambda$notifyListeners$2(SharedMemoryJavaFXMessager.java:257)
	at java.base/java.util.concurrent.ConcurrentLinkedQueue.forEachFrom(ConcurrentLinkedQueue.java:1037)
	at java.base/java.util.concurrent.ConcurrentLinkedQueue.forEach(ConcurrentLinkedQueue.java:1054)
	at us.ihmc.messager.javafx.SharedMemoryJavaFXMessager$JavaFXTopicListeners.notifyListeners(SharedMemoryJavaFXMessager.java:257)
	at us.ihmc.messager.javafx.SharedMemoryJavaFXMessager.updateFXTopicListeners(SharedMemoryJavaFXMessager.java:75)
	at us.ihmc.scs2.sessionVisualizer.jfx.tools.SCS2JavaFXMessager$1.handleImpl(SCS2JavaFXMessager.java:26)
	at us.ihmc.scs2.sessionVisualizer.jfx.tools.ObservedAnimationTimer.handle(ObservedAnimationTimer.java:24)
	at javafx.animation.AnimationTimer$AnimationTimerReceiver.lambda$handle$0(AnimationTimer.java:58)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
	at javafx.animation.AnimationTimer$AnimationTimerReceiver.handle(AnimationTimer.java:57)
	at com.sun.scenario.animation.AbstractPrimaryTimer.timePulseImpl(AbstractPrimaryTimer.java:356)
	at com.sun.scenario.animation.AbstractPrimaryTimer$MainLoop.run(AbstractPrimaryTimer.java:266)
	at com.sun.javafx.tk.quantum.QuantumToolkit.pulse(QuantumToolkit.java:571)
	at com.sun.javafx.tk.quantum.QuantumToolkit.pulse(QuantumToolkit.java:555)
	at com.sun.javafx.tk.quantum.QuantumToolkit.pulseFromQueue(QuantumToolkit.java:548)
	at com.sun.javafx.tk.quantum.QuantumToolkit.lambda$runToolkit$11(QuantumToolkit.java:353)
	at com.sun.glass.ui.InvokeLaterDispatcher$Future.run(InvokeLaterDispatcher.java:96)
	at com.sun.glass.ui.win.WinApplication._runLoop(Native Method)
	at com.sun.glass.ui.win.WinApplication.lambda$runLoop$3(WinApplication.java:184)
	at java.base/java.lang.Thread.run(Thread.java:833)`