### PR TITLE
[Feature] Added Camera Type to Deploy GUI

### DIFF
--- a/src/main/java/us/ihmc/publisher/logger/ui/CameraBean.java
+++ b/src/main/java/us/ihmc/publisher/logger/ui/CameraBean.java
@@ -1,13 +1,15 @@
 package us.ihmc.publisher.logger.ui;
 
+import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import us.ihmc.robotDataLogger.CameraConfiguration;
 import us.ihmc.robotDataLogger.CameraType;
 
 public class CameraBean
 {
-
+   public final ObjectProperty<CameraType> camera_type = new SimpleObjectProperty<>(CameraType.CAPTURE_CARD_MAGEWELL);
    public final SimpleStringProperty camera_name = new SimpleStringProperty();
    public final SimpleIntegerProperty camera_id = new SimpleIntegerProperty();
    public final SimpleIntegerProperty camera_input = new SimpleIntegerProperty();
@@ -17,13 +19,17 @@ public class CameraBean
       this.camera_id.set(id);
       camera_name.set("");
    }
-   
+
    public CameraBean(CameraConfiguration config)
    {
       camera_id.set(config.getCameraId());
       camera_input.set(Integer.valueOf(config.getIdentifierAsString()));
       camera_name.set(config.getNameAsString());
+   }
 
+   public CameraType getCamera_type()
+   {
+      return camera_type.get();
    }
 
    public String getCamera_name()
@@ -40,13 +46,12 @@ public class CameraBean
    {
       return camera_input.get();
    }
-   
+
    public void pack(CameraConfiguration camera)
    {
-      camera.setType(camera.getType());
+      camera.setType(getCamera_type());
       camera.setName(getCamera_name());
       camera.setCameraId((byte) getCamera_id());
       camera.setIdentifier(String.valueOf(getCamera_input()));
-
    }
 }

--- a/src/main/java/us/ihmc/publisher/logger/ui/CameraBean.java
+++ b/src/main/java/us/ihmc/publisher/logger/ui/CameraBean.java
@@ -43,7 +43,7 @@ public class CameraBean
    
    public void pack(CameraConfiguration camera)
    {
-      camera.setType(CameraType.CAPTURE_CARD);
+      camera.setType(camera.getType());
       camera.setName(getCamera_name());
       camera.setCameraId((byte) getCamera_id());
       camera.setIdentifier(String.valueOf(getCamera_input()));

--- a/src/main/java/us/ihmc/publisher/logger/ui/LoggerDeployApplication.java
+++ b/src/main/java/us/ihmc/publisher/logger/ui/LoggerDeployApplication.java
@@ -25,7 +25,7 @@ import us.ihmc.publisher.logger.utils.TeeStream;
 public class LoggerDeployApplication
 {
    private static final URL uiDescription = LoggerDeployApplication.class.getResource("LoggerSetup.fxml");
-   private String loggerDist;
+   private final String loggerDist;
 
    public LoggerDeployApplication(String loggerDist)
    {
@@ -34,8 +34,7 @@ public class LoggerDeployApplication
 
    /**
     * Helper function to open this as part of another application
-    * 
-    * @param parameters Parameters from application start
+    *
     * @param scene      Parent scene
     */
    public static void open(String loggerDistribution, LoggerDeployScript deployScript, Scene scene)
@@ -119,7 +118,7 @@ public class LoggerDeployApplication
 
       String loggerDist = config.getString("loggerDist");
 
-      
+
 
       PlatformImpl.startup(new Runnable()
       {

--- a/src/main/java/us/ihmc/publisher/logger/ui/LoggerDeployApplication.java
+++ b/src/main/java/us/ihmc/publisher/logger/ui/LoggerDeployApplication.java
@@ -34,7 +34,7 @@ public class LoggerDeployApplication
 
    /**
     * Helper function to open this as part of another application
-    *
+    * 
     * @param parameters Parameters from application start
     * @param scene      Parent scene
     */
@@ -119,7 +119,7 @@ public class LoggerDeployApplication
 
       String loggerDist = config.getString("loggerDist");
 
-
+      
 
       PlatformImpl.startup(new Runnable()
       {

--- a/src/main/java/us/ihmc/publisher/logger/ui/LoggerDeployApplication.java
+++ b/src/main/java/us/ihmc/publisher/logger/ui/LoggerDeployApplication.java
@@ -25,7 +25,7 @@ import us.ihmc.publisher.logger.utils.TeeStream;
 public class LoggerDeployApplication
 {
    private static final URL uiDescription = LoggerDeployApplication.class.getResource("LoggerSetup.fxml");
-   private final String loggerDist;
+   private String loggerDist;
 
    public LoggerDeployApplication(String loggerDist)
    {
@@ -35,6 +35,7 @@ public class LoggerDeployApplication
    /**
     * Helper function to open this as part of another application
     *
+    * @param parameters Parameters from application start
     * @param scene      Parent scene
     */
    public static void open(String loggerDistribution, LoggerDeployScript deployScript, Scene scene)

--- a/src/main/java/us/ihmc/publisher/logger/ui/LoggerDeployController.java
+++ b/src/main/java/us/ihmc/publisher/logger/ui/LoggerDeployController.java
@@ -131,7 +131,7 @@ public class LoggerDeployController implements Initializable
 
       camera_table.setEditable(true);
 
-      ObservableList<CameraType> cameraOptionsList = FXCollections.observableArrayList(CameraType.values());
+      ObservableList<CameraType> cameraOptionsList = FXCollections.observableArrayList(CameraType.values);
       camera_type_column.setCellFactory(ComboBoxTableCell.forTableColumn(cameraOptionsList));
       camera_type_column.setCellValueFactory(new PropertyValueFactory<CameraBean, CameraType>("camera_type"));
       camera_type_column.setOnEditCommit(e ->

--- a/src/main/java/us/ihmc/publisher/logger/ui/LoggerDeployController.java
+++ b/src/main/java/us/ihmc/publisher/logger/ui/LoggerDeployController.java
@@ -24,6 +24,7 @@ import javafx.scene.control.SelectionMode;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.control.TextField;
+import javafx.scene.control.cell.ComboBoxTableCell;
 import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.scene.control.cell.TextFieldTableCell;
 import javafx.stage.FileChooser;
@@ -59,6 +60,9 @@ public class LoggerDeployController implements Initializable
 
    @FXML
    TableView<CameraBean> camera_table;
+
+   @FXML
+   TableColumn<CameraBean, CameraType> camera_type_column;
 
    @FXML
    TableColumn<CameraBean, String> camera_name_col;
@@ -126,6 +130,14 @@ public class LoggerDeployController implements Initializable
       prefs.linkToPrefs(allow_many_instances, false);
 
       camera_table.setEditable(true);
+
+      ObservableList<CameraType> cameraOptionsList = FXCollections.observableArrayList(CameraType.values());
+      camera_type_column.setCellFactory(ComboBoxTableCell.forTableColumn(cameraOptionsList));
+      camera_type_column.setCellValueFactory(new PropertyValueFactory<CameraBean, CameraType>("camera_type"));
+      camera_type_column.setOnEditCommit(e ->
+                                         {
+                                            e.getRowValue().camera_type.set(e.getNewValue());
+                                         });
 
       camera_id_col.setCellValueFactory(new PropertyValueFactory<CameraBean, Integer>("camera_id"));
 

--- a/src/main/resources/us/ihmc/publisher/logger/ui/LoggerSetup.fxml
+++ b/src/main/resources/us/ihmc/publisher/logger/ui/LoggerSetup.fxml
@@ -114,9 +114,10 @@
                                     <children>
                                         <TableView fx:id="camera_table" prefHeight="480.0" prefWidth="1234.0" VBox.vgrow="ALWAYS">
                                             <columns>
-                                                <TableColumn fx:id="camera_id_col" prefWidth="244.5" text="ID"/>
-                                                <TableColumn fx:id="camera_name_col" prefWidth="318.0" text="Name"/>
-                                                <TableColumn fx:id="camera_input_col" prefWidth="193.0" text="Input Number"/>
+                                                <TableColumn fx:id="camera_type_column" prefWidth="250.0" text="Type"/>
+                                                <TableColumn fx:id="camera_id_col" prefWidth="50.0" text="ID"/>
+                                                <TableColumn fx:id="camera_name_col" prefWidth="325.0" text="Name"/>
+                                                <TableColumn fx:id="camera_input_col" prefWidth="125.0" text="Input Number"/>
                                             </columns>
                                         </TableView>
                                         <HBox prefHeight="100.0" prefWidth="200.0" spacing="5.0">


### PR DESCRIPTION
Added a feature where you can set the camera type from the deploy GUI. This makes it easier to use the Magewell stuff as that's the default option when adding a camera from the GUI.

![image](https://github.com/user-attachments/assets/9b4ac295-b42f-48e9-ab9e-7ace82de28a5)
