### PR TITLE
:arrow_up: zed-java-api 4.2.0_4

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,7 +70,7 @@ mainDependencies {
    api("us.ihmc:ffmpeg:$ffmpegVersion:windows-x86_64")
 
    // ZED SDK for logging remote ZED data streams
-   api("us.ihmc:zed-java-api:4.2.0_3")
+   api("us.ihmc:zed-java-api:4.2.0_4")
 
    api("org.freedesktop.gstreamer:gst1-java-core:1.4.0")
 


### PR DESCRIPTION
This upgrade of zed-java-api introduces commonly used classes we have duplicated in a couple places

https://github.com/ihmcrobotics/zed-java-api/releases/tag/4.2.0_4