### PR TITLE
Use a long[] array to put the data into the buffer after receiving the data from the web socket. Rather then do buffer.put(long) for each variable.

### DIFF
--- a/src/main/java/us/ihmc/robotDataLogger/logger/YoVariableLoggerListener.java
+++ b/src/main/java/us/ihmc/robotDataLogger/logger/YoVariableLoggerListener.java
@@ -20,7 +20,6 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.nio.LongBuffer;
 import java.nio.channels.FileChannel;
 import java.util.ArrayList;

--- a/src/main/java/us/ihmc/robotDataLogger/logger/YoVariableLoggerListener.java
+++ b/src/main/java/us/ihmc/robotDataLogger/logger/YoVariableLoggerListener.java
@@ -485,9 +485,10 @@ public class YoVariableLoggerListener implements YoVariablesUpdatedListener
       jointStates = handshakeParser.getJointStates();
 
       // Initialize disk format variables
-      // Allocate direct and native order give the best speeds
       dataBuffer = ByteBuffer.allocate(bufferSize);
       dataBufferAsLong = dataBuffer.asLongBuffer();
+
+      // We can do this because once we connect to a server we don't expect the number of YoVariables to change while we are running
       dataAsLong = new long[variables.size()];
 
       File dataFile = new File(tempDirectory, dataFilename);

--- a/src/main/java/us/ihmc/robotDataLogger/logger/YoVariableLoggerListener.java
+++ b/src/main/java/us/ihmc/robotDataLogger/logger/YoVariableLoggerListener.java
@@ -486,7 +486,7 @@ public class YoVariableLoggerListener implements YoVariablesUpdatedListener
 
       // Initialize disk format variables
       // Allocate direct and native order give the best speeds
-      dataBuffer = ByteBuffer.allocateDirect(bufferSize).order(ByteOrder.nativeOrder());
+      dataBuffer = ByteBuffer.allocate(bufferSize);
       dataBufferAsLong = dataBuffer.asLongBuffer();
       dataAsLong = new long[variables.size()];
 

--- a/src/main/java/us/ihmc/robotDataLogger/logger/YoVariableLoggerListener.java
+++ b/src/main/java/us/ihmc/robotDataLogger/logger/YoVariableLoggerListener.java
@@ -20,6 +20,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.LongBuffer;
 import java.nio.channels.FileChannel;
 import java.util.ArrayList;
@@ -87,6 +88,7 @@ public class YoVariableLoggerListener implements YoVariablesUpdatedListener
    private List<JointState> jointStates;
    private ByteBuffer dataBuffer;
    private LongBuffer dataBufferAsLong;
+   private long[] dataAsLong;
 
    private YoVariableClientInterface yoVariableClientInterface = null;
 
@@ -320,14 +322,16 @@ public class YoVariableLoggerListener implements YoVariablesUpdatedListener
 
    protected ByteBuffer reconstructBuffer(long timestamp)
    {
-      dataBuffer.clear();
       dataBufferAsLong.clear();
 
       dataBufferAsLong.put(timestamp);
       for (int i = 0; i < variables.size(); i++)
       {
-         dataBufferAsLong.put(variables.get(i).getValueAsLongBits());
+         dataAsLong[i] = variables.get(i).getValueAsLongBits();
       }
+
+      // Avoid .put() in the loop as there is a lot of overhead involved
+      dataBufferAsLong.put(dataAsLong);
 
       for (int i = 0; i < jointStates.size(); i++)
       {
@@ -477,11 +481,14 @@ public class YoVariableLoggerListener implements YoVariablesUpdatedListener
       int bufferSize = handshakeParser.getBufferSize();
       compressedBuffer = ByteBuffer.allocate(SnappyUtils.maxCompressedLength(bufferSize));
 
-      // Initialize disk format variables
-      dataBuffer = ByteBuffer.allocate(bufferSize);
-      dataBufferAsLong = dataBuffer.asLongBuffer();
       variables = handshakeParser.getYoVariablesList();
       jointStates = handshakeParser.getJointStates();
+
+      // Initialize disk format variables
+      // Allocate direct and native order give the best speeds
+      dataBuffer = ByteBuffer.allocateDirect(bufferSize).order(ByteOrder.nativeOrder());
+      dataBufferAsLong = dataBuffer.asLongBuffer();
+      dataAsLong = new long[variables.size()];
 
       File dataFile = new File(tempDirectory, dataFilename);
       File indexFile = new File(tempDirectory, indexFilename);


### PR DESCRIPTION
This is faster then calling buffer.put(long) for each variable because there is less checks when you do longArray[i] = longData.

I've been investigating why we are losing data in our logs. Was profiling this method and saw it was one of the slower parts. This speeds it up slightly. Not significant (aka doesn't fixt the problem) but helps eliminate a slowness in logging.