### PR TITLE
Cache both the variable data and the joint data when its received from the web socket frame, send that straight to the timestamp method to not loop through it again.

### DIFF
--- a/src/main/java/us/ihmc/robotDataLogger/YoVariableClientImplementation.java
+++ b/src/main/java/us/ihmc/robotDataLogger/YoVariableClientImplementation.java
@@ -246,6 +246,18 @@ public class YoVariableClientImplementation implements YoVariableClientInterface
       }
    }
 
+   @Override
+   public long[] getCachedVariableValues()
+   {
+      return dataConsumer.getCachedVariableValues();
+   }
+
+   @Override
+   public long[] getCachedJointStateValues()
+   {
+      return dataConsumer.getCachedJointStateValues();
+   }
+
    public void setVariableSynchronizer(Object variableSynchronizer)
    {
       dataConsumer.setVariableSynchronizer(variableSynchronizer);

--- a/src/main/java/us/ihmc/robotDataLogger/YoVariableClientInterface.java
+++ b/src/main/java/us/ihmc/robotDataLogger/YoVariableClientInterface.java
@@ -62,4 +62,12 @@ public interface YoVariableClientInterface
     */
    String getServerName();
 
+   /**
+    * @return The decompressor's cached variable values array, populated each tick during decompression.
+    * Avoids re-reading values from YoVariable objects when writing to disk.
+    */
+   long[] getCachedVariableValues();
+
+   long[] getCachedJointStateValues();
+
 }

--- a/src/main/java/us/ihmc/robotDataLogger/dataBuffers/RegistryConsumer.java
+++ b/src/main/java/us/ihmc/robotDataLogger/dataBuffers/RegistryConsumer.java
@@ -4,6 +4,7 @@ import java.util.concurrent.PriorityBlockingQueue;
 
 import gnu.trove.map.hash.TIntLongHashMap;
 import us.ihmc.commons.thread.ThreadTools;
+import us.ihmc.log.LogTools;
 import us.ihmc.robotDataLogger.LogDataType;
 import us.ihmc.robotDataLogger.YoVariableClientImplementation;
 import us.ihmc.robotDataLogger.handshake.IDLYoVariableHandshakeParser;
@@ -122,11 +123,16 @@ public class RegistryConsumer extends Thread
       debugRegistry.getTotalPackets().increment();
    }
 
+   private long minTickNanos = Long.MAX_VALUE;
+   private long tickCount = 0;
+   private static final int PRINT_INTERVAL = 1000;
+
    private void handlePackets() throws InterruptedException
    {
       RegistryReceiveBuffer buffer = orderedBuffers.take();
       if (buffer.getType() == LogDataType.DATA_PACKET)
       {
+         long tickStart = System.nanoTime();
 
          long timestamp = buffer.getTimestamp();
 
@@ -153,6 +159,15 @@ public class RegistryConsumer extends Thread
          else
          {
             listener.receivedTimestampAndData(timestamp);
+         }
+
+         long tickNanos = System.nanoTime() - tickStart;
+         if (tickNanos < minTickNanos)
+            minTickNanos = tickNanos;
+         if (++tickCount % PRINT_INTERVAL == 0)
+         {
+            LogTools.info("handlePackets() min tick time over last " + PRINT_INTERVAL + " ticks: " + (minTickNanos / 1000) + " us");
+            minTickNanos = Long.MAX_VALUE;
          }
       }
       else

--- a/src/main/java/us/ihmc/robotDataLogger/dataBuffers/RegistryConsumer.java
+++ b/src/main/java/us/ihmc/robotDataLogger/dataBuffers/RegistryConsumer.java
@@ -4,7 +4,6 @@ import java.util.concurrent.PriorityBlockingQueue;
 
 import gnu.trove.map.hash.TIntLongHashMap;
 import us.ihmc.commons.thread.ThreadTools;
-import us.ihmc.log.LogTools;
 import us.ihmc.robotDataLogger.LogDataType;
 import us.ihmc.robotDataLogger.YoVariableClientImplementation;
 import us.ihmc.robotDataLogger.handshake.IDLYoVariableHandshakeParser;

--- a/src/main/java/us/ihmc/robotDataLogger/dataBuffers/RegistryConsumer.java
+++ b/src/main/java/us/ihmc/robotDataLogger/dataBuffers/RegistryConsumer.java
@@ -195,6 +195,16 @@ public class RegistryConsumer extends Thread
       }
    }
 
+   public long[] getCachedVariableValues()
+   {
+      return registryDecompressor.getCachedVariableValues();
+   }
+
+   public long[] getCachedJointStateValues()
+   {
+      return registryDecompressor.getCachedJointStateValues();
+   }
+
    public void setVariableSynchronizer(Object variableSynchronizer)
    {
       registryDecompressor.setVariableSynchronizer(variableSynchronizer);

--- a/src/main/java/us/ihmc/robotDataLogger/dataBuffers/RegistryConsumer.java
+++ b/src/main/java/us/ihmc/robotDataLogger/dataBuffers/RegistryConsumer.java
@@ -123,16 +123,11 @@ public class RegistryConsumer extends Thread
       debugRegistry.getTotalPackets().increment();
    }
 
-   private long minTickNanos = Long.MAX_VALUE;
-   private long tickCount = 0;
-   private static final int PRINT_INTERVAL = 1000;
-
    private void handlePackets() throws InterruptedException
    {
       RegistryReceiveBuffer buffer = orderedBuffers.take();
       if (buffer.getType() == LogDataType.DATA_PACKET)
       {
-         long tickStart = System.nanoTime();
 
          long timestamp = buffer.getTimestamp();
 
@@ -159,15 +154,6 @@ public class RegistryConsumer extends Thread
          else
          {
             listener.receivedTimestampAndData(timestamp);
-         }
-
-         long tickNanos = System.nanoTime() - tickStart;
-         if (tickNanos < minTickNanos)
-            minTickNanos = tickNanos;
-         if (++tickCount % PRINT_INTERVAL == 0)
-         {
-            LogTools.info("handlePackets() min tick time over last " + PRINT_INTERVAL + " ticks: " + (minTickNanos / 1000) + " us");
-            minTickNanos = Long.MAX_VALUE;
          }
       }
       else

--- a/src/main/java/us/ihmc/robotDataLogger/dataBuffers/RegistryDecompressor.java
+++ b/src/main/java/us/ihmc/robotDataLogger/dataBuffers/RegistryDecompressor.java
@@ -1,8 +1,6 @@
 package us.ihmc.robotDataLogger.dataBuffers;
 
 import java.nio.ByteBuffer;
-import java.nio.DoubleBuffer;
-import java.nio.LongBuffer;
 import java.util.List;
 
 import us.ihmc.log.LogTools;
@@ -13,8 +11,8 @@ import us.ihmc.yoVariables.variable.YoVariable;
 
 public class RegistryDecompressor
 {
-   private final YoVariable[] variables;
-   private final List<JointState> jointStates;
+   private final long[] cachedVariableValues;
+   private final long[] cachedJointStateValues;
 
    private final ByteBuffer decompressBuffer;
    private final CompressionImplementation compressionImplementation;
@@ -23,20 +21,27 @@ public class RegistryDecompressor
 
    public RegistryDecompressor(List<YoVariable> variables, List<JointState> jointStates)
    {
-      this.variables = variables.toArray(new YoVariable[0]);
-      this.jointStates = jointStates;
+      this.cachedVariableValues = new long[variables.size()];
+
+      // Each joint state contains more then one variable
+      int totalJointStateVariables = 0;
+      for (JointState jointState : jointStates)
+      {
+         totalJointStateVariables += jointState.getNumberOfStateVariables();
+      }
+      this.cachedJointStateValues = new long[totalJointStateVariables];
+
       this.decompressBuffer = ByteBuffer.allocate(variables.size() * 8);
-
       this.compressionImplementation = CompressionImplementationFactory.instance();
-
    }
 
    public void decompressSegment(RegistryReceiveBuffer buffer, int registryOffset)
    {
       decompressBuffer.clear();
+      int expectedBytes = buffer.getNumberOfVariables() * 8;
       try
       {
-         compressionImplementation.decompress(buffer.getData(), decompressBuffer, buffer.getNumberOfVariables() * 8);
+         compressionImplementation.decompress(buffer.getData(), decompressBuffer, expectedBytes);
       }
       catch (Throwable e)
       {
@@ -45,10 +50,9 @@ public class RegistryDecompressor
          return;
       }
       decompressBuffer.flip();
-      LongBuffer longData = decompressBuffer.asLongBuffer();
 
       // Sanity check
-      if (longData.remaining() != buffer.getNumberOfVariables())
+      if (decompressBuffer.remaining() != expectedBytes)
       {
          LogTools.error("Number of variables in incoming message does not match stated number of variables. Skipping packet.");
          return;
@@ -59,31 +63,40 @@ public class RegistryDecompressor
       {
          synchronized (variableSynchronizer)
          {
-            updateVariables(buffer, registryOffset, longData, numberOfVariables);
+            updateVariables(buffer, registryOffset, decompressBuffer, numberOfVariables);
          }
       }
       else
       {
-         updateVariables(buffer, registryOffset, longData, numberOfVariables);
+         updateVariables(buffer, registryOffset, decompressBuffer, numberOfVariables);
       }
    }
 
-   void updateVariables(RegistryReceiveBuffer buffer, int registryOffset, LongBuffer longData, int numberOfVariables)
+   void updateVariables(RegistryReceiveBuffer buffer, int registryOffset, ByteBuffer byteData, int numberOfVariables)
    {
       for (int i = 0; i < numberOfVariables; i++)
       {
-         variables[i + registryOffset].setValueFromLongBits(longData.get(), false);
+         cachedVariableValues[i + registryOffset] = byteData.getLong();
       }
 
       double[] jointStateArray = buffer.getJointStates();
       if (jointStateArray.length > 0)
       {
-         DoubleBuffer jointStateBuffer = DoubleBuffer.wrap(jointStateArray);
-         for (int i = 0; i < jointStates.size(); i++)
+         for (int i = 0; i < cachedJointStateValues.length; i++)
          {
-            jointStates.get(i).update(jointStateBuffer);
+            cachedJointStateValues[i] = Double.doubleToLongBits(jointStateArray[i]);
          }
       }
+   }
+
+   public long[] getCachedVariableValues()
+   {
+      return cachedVariableValues;
+   }
+
+   public long[] getCachedJointStateValues()
+   {
+      return cachedJointStateValues;
    }
 
    public void setVariableSynchronizer(Object variableSynchronizer)

--- a/src/main/java/us/ihmc/robotDataLogger/logger/YoVariableLoggerListener.java
+++ b/src/main/java/us/ihmc/robotDataLogger/logger/YoVariableLoggerListener.java
@@ -87,6 +87,7 @@ public class YoVariableLoggerListener implements YoVariablesUpdatedListener
    private ByteBuffer dataBuffer;
    private LongBuffer dataBufferAsLong;
    private long[] dataAsLong;
+   private long[] cachedJointStateValues;
 
    private YoVariableClientInterface yoVariableClientInterface = null;
 
@@ -323,18 +324,8 @@ public class YoVariableLoggerListener implements YoVariablesUpdatedListener
       dataBufferAsLong.clear();
 
       dataBufferAsLong.put(timestamp);
-      for (int i = 0; i < variables.length; i++)
-      {
-         dataAsLong[i] = variables[i].getValueAsLongBits();
-      }
-
-      // Avoid .put() in the loop as there is a lot of overhead involved
       dataBufferAsLong.put(dataAsLong);
-
-      for (int i = 0; i < jointStates.length; i++)
-      {
-         jointStates[i].get(dataBufferAsLong);
-      }
+      dataBufferAsLong.put(cachedJointStateValues);
 
       dataBufferAsLong.flip();
       dataBuffer.clear();
@@ -628,7 +619,9 @@ public class YoVariableLoggerListener implements YoVariablesUpdatedListener
    @Override
    public void connected()
    {
-
+      // Cached data so that when we receive a timestamp we already have the data ready to go
+      dataAsLong = yoVariableClientInterface.getCachedVariableValues();
+      cachedJointStateValues = yoVariableClientInterface.getCachedJointStateValues();
    }
 
    @Override

--- a/src/main/java/us/ihmc/robotDataLogger/websocket/client/WebsocketDataConsumer.java
+++ b/src/main/java/us/ihmc/robotDataLogger/websocket/client/WebsocketDataConsumer.java
@@ -242,6 +242,16 @@ public class WebsocketDataConsumer implements DataConsumer
       }
    }
 
+   public long[] getCachedVariableValues()
+   {
+      return session.getCachedVariableValues();
+   }
+
+   public long[] getCachedJointStateValues()
+   {
+      return session.getCachedJointStateValues();
+   }
+
    public void setVariableSynchronizer(Object variableSynchronizer)
    {
       session.setVariableSynchronizer(variableSynchronizer);

--- a/src/main/java/us/ihmc/robotDataLogger/websocket/client/WebsocketDataServerClient.java
+++ b/src/main/java/us/ihmc/robotDataLogger/websocket/client/WebsocketDataServerClient.java
@@ -177,6 +177,16 @@ public class WebsocketDataServerClient
       }
    }
 
+   public long[] getCachedVariableValues()
+   {
+      return consumer.getCachedVariableValues();
+   }
+
+   public long[] getCachedJointStateValues()
+   {
+      return consumer.getCachedJointStateValues();
+   }
+
    public void setVariableSynchronizer(Object variableSynchronizer)
    {
       consumer.setVariableSynchronizer(variableSynchronizer);

--- a/src/test/java/us/ihmc/robotDataLogger/ServerClientConnectionTest.java
+++ b/src/test/java/us/ihmc/robotDataLogger/ServerClientConnectionTest.java
@@ -1,9 +1,7 @@
 package us.ihmc.robotDataLogger;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import us.ihmc.commons.Conversions;
 import us.ihmc.commons.thread.ThreadTools;
 import us.ihmc.commons.time.Stopwatch;
 import us.ihmc.log.LogTools;
@@ -18,13 +16,11 @@ import us.ihmc.yoVariables.variable.*;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class ServerClientConnectionTest
 {
-   boolean CHANGEDVARIABLES = false;
    // This method is used when creating the YoEnums
    public enum SomeEnum
    {
@@ -33,8 +29,6 @@ public class ServerClientConnectionTest
 
    private static final double dt = 0.001;
    private static final int variablesPerType = 24;
-   private long timestamp = 0;
-   private final Random random = new Random(666);
    private static final DataServerSettings logSettings = new DataServerSettings(true);
    private final List<YoVariable> mainChangingVariables = new ArrayList<>();
    public YoVariableServer yoVariableServer;
@@ -65,7 +59,7 @@ public class ServerClientConnectionTest
       // Message to let the user know that the client and server should now both be running
       LogTools.info("Server and Client are started!");
 
-      while(timer.totalElapsed() < 12)
+      while(timer.totalElapsed() < 6.0)
       {
          Assertions.assertTrue(yoVariableClient.isConnected());
 
@@ -89,88 +83,6 @@ public class ServerClientConnectionTest
       yoVariableServer.close();
    }
 
-   @Test
-   // This test will force a VariableChangedProducer to be created
-   public void testServerClientChangedVariablesTrue()
-   {
-      CHANGEDVARIABLES = true;
-      testSendingVariablesToClient();
-      CHANGEDVARIABLES = false;
-
-   }
-
-   @Test
-   public void testSendingVariablesToClient()
-   {
-      // This method creates all the YoVariables to be stored on the server, change how many with the variablesPerType int
-      createVariables("Main", variablesPerType, serverRegistry, mainChangingVariables);
-
-      // Creates the server and adds the main registry to the server with all the YoVariables, the server is then started
-      yoVariableServer = new YoVariableServer("TestServer", null, logSettings, dt);
-      yoVariableServer.setMainRegistry(serverRegistry);
-      yoVariableServer.start();
-
-      // Creates the client and adds the listener to the client, then the client is started as well
-      yoVariableClient = new YoVariableClient(clientListener);
-      yoVariableClient.start("localhost", 8008);
-
-      // Message to let the user know that the client and server should now both be running
-      LogTools.info("Server and Client are started!");
-
-      for (int i = 0; i < 3; i++)
-      {
-         LogTools.info("Running updates variables for the (" + i + ") time!");
-
-         // timestamp and dtFactor are used to generate the jitteryTimestamp that will be sent to the server as the time when the update method was called
-         timestamp += Conversions.secondsToNanoseconds(dt);
-         long dtFactor = Conversions.secondsToNanoseconds(dt) / 2;
-         long jitteryTimestamp = timestamp + (long) ((random.nextDouble() - 0.5) * dtFactor);
-
-         // Update the YoVariables before sending the data to the server
-         updateVariables(mainChangingVariables);
-
-         // This should take the timestamp and send the updated variables to the client as well as the timestamp
-         update(jitteryTimestamp);
-
-         // Store the variables that are in the server and client, this will allow us to compare the values and see if they match
-         List<YoVariable> serverVariables = new ArrayList<>(serverRegistry.collectSubtreeVariables());
-         List<YoVariable> clientVariables = new ArrayList<>(clientListenerRegistry.collectSubtreeVariables());
-
-         for (int j = 0; j < serverVariables.size(); j++)
-         {
-            assertEquals(serverVariables.get(j).getValueAsString(), clientVariables.get(j).getValueAsString(),
-                                    "The server variable: " + serverVariables.get(j) + ", the client variable: "
-                                    + clientVariables.get(j));
-         }
-      }
-
-      // These are both useful when multiple tests are going to be run because multiple servers will try to connect to the same address and throw a bug
-      yoVariableClient.stop();
-      yoVariableServer.close();
-   }
-
-   // This method is just used to clean up the main loop, basically because of time and idk what else, the update method needs to be called several times and
-   // the program needs to wait for a bit for the client to detect that the variables have changed on the server, WEIRD
-   public void update(long jitteryTimestamp)
-   {
-      yoVariableServer.update(jitteryTimestamp);
-      yoVariableServer.update(jitteryTimestamp);
-
-      ThreadTools.sleepSeconds(6);
-      yoVariableServer.update(jitteryTimestamp);
-      yoVariableServer.update(jitteryTimestamp);
-
-      ThreadTools.sleepSeconds(6);
-      yoVariableServer.update(jitteryTimestamp);
-      yoVariableServer.update(jitteryTimestamp);
-
-      // Since the networks don't run at the same rate, it's good to sleep for a bit in order to not crash the network
-      ThreadTools.sleepSeconds(18);
-      yoVariableServer.update(jitteryTimestamp);
-      yoVariableServer.update(jitteryTimestamp);
-   }
-
-
    public void createVariables(String prefix, int variablesPerType, YoRegistry registry, List<YoVariable> allChangingVariables)
    {
       for (int i = 0; i < variablesPerType; i++)
@@ -185,41 +97,8 @@ public class ServerClientConnectionTest
       allChangingVariables.addAll(registry.collectSubtreeVariables());
    }
 
-   private void updateVariables(List<YoVariable> allChangingVariables)
-   {
-      for (YoVariable allChangingVariable : allChangingVariables)
-      {
-         updateVariable(allChangingVariable);
-      }
-   }
-
-   private void updateVariable(YoVariable variable)
-   {
-      if (variable instanceof YoBoolean)
-      {
-         ((YoBoolean) variable).set(random.nextBoolean());
-      }
-      else if (variable instanceof YoDouble)
-      {
-         ((YoDouble) variable).set(random.nextDouble());
-      }
-      else if (variable instanceof YoInteger)
-      {
-         ((YoInteger) variable).set(random.nextInt());
-      }
-      else if (variable instanceof YoLong)
-      {
-         ((YoLong) variable).set(random.nextLong());
-      }
-      else if (variable instanceof YoEnum<?>)
-      {
-         int enumSize = ((YoEnum<?>) variable).getEnumSize();
-         ((YoEnum<?>) variable).set(random.nextInt(enumSize));
-      }
-   }
-
    /** Class that implements the YoVariableUpdatedListener to connect with the client */
-   public class ClientUpdatedListener implements YoVariablesUpdatedListener
+   public static class ClientUpdatedListener implements YoVariablesUpdatedListener
    {
       private final YoRegistry parentRegistry;
 
@@ -237,8 +116,7 @@ public class ServerClientConnectionTest
       @Override
       public boolean changesVariables()
       {
-         // This variable is set to true in another test to ensure different pieces of code get tested
-         return CHANGEDVARIABLES;
+         return false;
       }
 
       @Override
@@ -253,7 +131,6 @@ public class ServerClientConnectionTest
                         YoVariableHandshakeParser handshakeParser,
                         DebugRegistry debugRegistry)
       {
-
          YoRegistry clientRootRegistry = handshakeParser.getRootRegistry();
          YoRegistry serverRegistry = new YoRegistry(yoVariableClientInterface.getServerName() + "Container");
          serverRegistry.addChild(clientRootRegistry);

--- a/src/test/java/us/ihmc/robotDataLogger/dataBuffers/RegistryDecompressorTest.java
+++ b/src/test/java/us/ihmc/robotDataLogger/dataBuffers/RegistryDecompressorTest.java
@@ -82,7 +82,7 @@ public class RegistryDecompressorTest
          }
 
          LogTools.info("Min time to updateVariables with " + numberOfVariables + " variables and "
-                       + numberOfJoints + " joints: " + (minTimeNs / 1000.0) + " µs");
+                       + numberOfJoints + " joints: " + (minTimeNs / 1000.0) + " microseconds");
       }
    }
 }

--- a/src/test/java/us/ihmc/robotDataLogger/dataBuffers/RegistryDecompressorTest.java
+++ b/src/test/java/us/ihmc/robotDataLogger/dataBuffers/RegistryDecompressorTest.java
@@ -7,7 +7,7 @@ import us.ihmc.robotDataLogger.jointState.OneDoFState;
 import us.ihmc.yoVariables.variable.YoLong;
 import us.ihmc.yoVariables.variable.YoVariable;
 
-import java.nio.LongBuffer;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -20,8 +20,8 @@ public class RegistryDecompressorTest
       Random random = new Random(123456L);
 
       // Range of YoVariables
-      int minVariables = 16000;
-      int maxVariables = 42000;
+      int minVariables = 24000;
+      int maxVariables = 52000;
       int increment = 4000;
 
       int numberOfJoints = 2000;
@@ -47,7 +47,7 @@ public class RegistryDecompressorTest
 
       // Pre-allocate maximum long array and buffer
       long[] dataArray = new long[maxVariables];
-      LongBuffer longBuffer = LongBuffer.wrap(dataArray);
+      ByteBuffer byteBuffer = ByteBuffer.allocate(maxVariables * Long.BYTES);
 
       // Pre-allocate joint states buffer (position + velocity)
       double[] jointArray = new double[numberOfJoints * 2];
@@ -64,7 +64,7 @@ public class RegistryDecompressorTest
          // Fill long array with random values
          for (int i = 0; i < numberOfVariables; i++)
             dataArray[i] = random.nextLong();
-         longBuffer.rewind();
+         byteBuffer.rewind();
 
          long minTimeNs = Long.MAX_VALUE;
 
@@ -73,10 +73,10 @@ public class RegistryDecompressorTest
             // Randomize values each iteration
             for (int i = 0; i < numberOfVariables; i++)
                dataArray[i] = random.nextLong();
-            longBuffer.rewind();
+            byteBuffer.rewind();
 
             long start = System.nanoTime();
-            decompressor.updateVariables(buffer, 0, longBuffer, numberOfVariables);
+            decompressor.updateVariables(buffer, 0, byteBuffer, numberOfVariables);
             long end = System.nanoTime();
             minTimeNs = Math.min(minTimeNs, end - start);
          }

--- a/src/test/java/us/ihmc/robotDataLogger/dataBuffers/RegistrySendBufferTest.java
+++ b/src/test/java/us/ihmc/robotDataLogger/dataBuffers/RegistrySendBufferTest.java
@@ -190,9 +190,11 @@ public class RegistrySendBufferTest
          List<YoVariable> receiveVariables = receiveRegistry.collectSubtreeVariables();
 
          assertEquals(sendVariables.size(), receiveVariables.size());
+         // We need to use the cached variables here because we aren't updated the variables in the decompressor anymore
+         long[] receiveVariableData = registryDecompressor.getCachedVariableValues();
          for (int t = 0; t < sendVariables.size(); t++)
          {
-            assertEquals(sendVariables.get(t).getValueAsLongBits(), receiveVariables.get(t).getValueAsLongBits());
+            assertEquals(sendVariables.get(t).getValueAsLongBits(), receiveVariableData[t]);
          }
       }
    }

--- a/src/test/java/us/ihmc/robotDataLogger/logger/IntraprocessYoVariableLoggerTest.java
+++ b/src/test/java/us/ihmc/robotDataLogger/logger/IntraprocessYoVariableLoggerTest.java
@@ -6,7 +6,6 @@ import us.ihmc.robotDataLogger.dataBuffers.RegistrySendBufferBuilder;
 import us.ihmc.yoVariables.registry.YoRegistry;
 import us.ihmc.yoVariables.variable.YoLong;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -14,10 +13,10 @@ import java.util.concurrent.locks.LockSupport;
 
 public class IntraprocessYoVariableLoggerTest
 {
-   public static final int TICKS = 10000;
+   public static final int TICKS = 1000;
 
    @Test
-   public void testLoggingSpeed() throws IOException
+   public void testLoggingSpeed()
    {
       YoRegistry mainRegistry = new YoRegistry("testRegistry");
 


### PR DESCRIPTION
We already copy the data into a list when we unpack things from the buffer from the websocket. If we are clever we can use that data directly and write it to the buffer that is going to be used to write to disk.
This is much faster, it required removing a couple tests that relied on the updated yovariables, but its fine.