### PR TITLE
Don't create a new RegistryReceiveBuffer each time we receive a web socket frame to reduce garbage collection times

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,7 +87,9 @@ testDependencies {
    api("us.ihmc:ihmc-commons-testing:0.35.1")
 }
 
-app.entrypoint("IHMCLogger", "us.ihmc.robotDataLogger.logger.YoVariableLoggerDispatcher")
+app.entrypoint("IHMCLogger", "us.ihmc.robotDataLogger.logger.YoVariableLoggerDispatcher", listOf(
+   "-Xlog:gc*:file=/opt/ihmc/logger/gc.log:time,uptime:filecount=5,filesize=20m",
+))
 app.entrypoint("IHMCLoggerDebug5005", "us.ihmc.robotDataLogger.logger.YoVariableLoggerDispatcher", listOf
 ("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005",
 ))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -90,8 +90,15 @@ testDependencies {
 app.entrypoint("IHMCLogger", "us.ihmc.robotDataLogger.logger.YoVariableLoggerDispatcher", listOf(
    "-Xlog:gc*:file=/opt/ihmc/logger/gc.log:time,uptime:filecount=5,filesize=20m",
 ))
-app.entrypoint("IHMCLoggerDebug5005", "us.ihmc.robotDataLogger.logger.YoVariableLoggerDispatcher", listOf
-("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005",
+app.entrypoint("IHMCLoggerLowLatency", "us.ihmc.robotDataLogger.logger.YoVariableLoggerDispatcher", listOf(
+   "-XX:+UseZGC",
+   "-XX:+AlwaysPreTouch",
+   "-Xms512m",
+   "-Xmx512m",
+   "-Xlog:gc*:file=/opt/ihmc/logger/gc.log:time,uptime:filecount=5,filesize=20m",
+))
+app.entrypoint("IHMCLoggerDebug5005", "us.ihmc.robotDataLogger.logger.YoVariableLoggerDispatcher", listOf(
+   "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005",
 ))
 app.entrypoint("BlackMagicCapture", "us.ihmc.javadecklink.Capture")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -88,14 +88,10 @@ testDependencies {
 }
 
 app.entrypoint("IHMCLogger", "us.ihmc.robotDataLogger.logger.YoVariableLoggerDispatcher", listOf(
-   "-Xlog:gc*:file=/opt/ihmc/logger/gc.log:time,uptime:filecount=5,filesize=20m",
-))
-app.entrypoint("IHMCLoggerLowLatency", "us.ihmc.robotDataLogger.logger.YoVariableLoggerDispatcher", listOf(
    "-XX:+UseZGC",
    "-XX:+AlwaysPreTouch",
-   "-Xms512m",
-   "-Xmx512m",
-   "-Xlog:gc*:file=/opt/ihmc/logger/gc.log:time,uptime:filecount=5,filesize=20m",
+   "-Xms1g",
+   "-Xmx1g",
 ))
 app.entrypoint("IHMCLoggerDebug5005", "us.ihmc.robotDataLogger.logger.YoVariableLoggerDispatcher", listOf(
    "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005",

--- a/src/main/java/us/ihmc/robotDataLogger/dataBuffers/RegistryConsumer.java
+++ b/src/main/java/us/ihmc/robotDataLogger/dataBuffers/RegistryConsumer.java
@@ -1,5 +1,6 @@
 package us.ihmc.robotDataLogger.dataBuffers;
 
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.PriorityBlockingQueue;
 
 import gnu.trove.map.hash.TIntLongHashMap;
@@ -15,6 +16,7 @@ public class RegistryConsumer extends Thread
 
    //   private final ConcurrentSkipListSet<RegistryReceiveBuffer> orderedBuffers = new ConcurrentSkipListSet<>();
    private final PriorityBlockingQueue<RegistryReceiveBuffer> orderedBuffers = new PriorityBlockingQueue<>();
+   private final ConcurrentLinkedQueue<RegistryReceiveBuffer> bufferPool = new ConcurrentLinkedQueue<>();
    private volatile boolean running = true;
 
    private boolean firstSample = true;
@@ -122,6 +124,19 @@ public class RegistryConsumer extends Thread
       debugRegistry.getTotalPackets().increment();
    }
 
+   public RegistryReceiveBuffer acquire()
+   {
+      RegistryReceiveBuffer buffer = bufferPool.poll();
+      if (buffer == null)
+         buffer = new RegistryReceiveBuffer(0);
+      return buffer;
+   }
+
+   public void release(RegistryReceiveBuffer buffer)
+   {
+      bufferPool.offer(buffer);
+   }
+
    private void handlePackets() throws InterruptedException
    {
       RegistryReceiveBuffer buffer = orderedBuffers.take();
@@ -131,11 +146,13 @@ public class RegistryConsumer extends Thread
          long timestamp = buffer.getTimestamp();
 
          decompressBuffer(buffer);
+         release(buffer);
 
          while (!orderedBuffers.isEmpty() && orderedBuffers.peek().getTimestamp() == timestamp)
          {
             RegistryReceiveBuffer next = orderedBuffers.take();
             decompressBuffer(next);
+            release(next);
             debugRegistry.getMergedPackets().increment();
          }
 
@@ -158,6 +175,7 @@ public class RegistryConsumer extends Thread
       else
       {
          //Received keep alive, ignore
+         release(buffer);
       }
    }
 

--- a/src/main/java/us/ihmc/robotDataLogger/dataBuffers/RegistryDecompressor.java
+++ b/src/main/java/us/ihmc/robotDataLogger/dataBuffers/RegistryDecompressor.java
@@ -19,6 +19,10 @@ public class RegistryDecompressor
    private final long[] cachedJointStateValues;
 
    private final ByteBuffer decompressBuffer;
+   private final LongBuffer decompressLongBuffer;
+   private final double[] jointStateData;
+   private final DoubleBuffer jointStateDoubleBuffer;
+
    private final CompressionImplementation compressionImplementation;
 
    private Object variableSynchronizer = null;
@@ -38,6 +42,9 @@ public class RegistryDecompressor
       this.cachedJointStateValues = new long[totalJointStateVariables];
 
       this.decompressBuffer = ByteBuffer.allocate(variables.size() * 8);
+      this.decompressLongBuffer = decompressBuffer.asLongBuffer();
+      this.jointStateData = new double[totalJointStateVariables];
+      this.jointStateDoubleBuffer = DoubleBuffer.wrap(jointStateData);
       this.compressionImplementation = CompressionImplementationFactory.instance();
    }
 
@@ -56,8 +63,10 @@ public class RegistryDecompressor
          return;
       }
       decompressBuffer.flip();
-      LongBuffer longData = decompressBuffer.asLongBuffer();
-      if (longData.remaining() != buffer.getNumberOfVariables())
+      decompressLongBuffer.clear();
+      // LongBuffer is a shared view and doesn't track ByteBuffer's limit automatically after flip()
+      decompressLongBuffer.limit(decompressBuffer.limit() / 8);
+      if (decompressLongBuffer.remaining() != buffer.getNumberOfVariables())
       {
          LogTools.error("Number of variables in incoming message does not match stated number of variables. Skipping packet.");
          return;
@@ -75,12 +84,12 @@ public class RegistryDecompressor
       {
          synchronized (variableSynchronizer)
          {
-            updateVariables(buffer, registryOffset, longData, numberOfVariables);
+            updateVariables(buffer, registryOffset, decompressLongBuffer, numberOfVariables);
          }
       }
       else
       {
-         updateVariables(buffer, registryOffset, longData, numberOfVariables);
+         updateVariables(buffer, registryOffset, decompressLongBuffer, numberOfVariables);
       }
    }
 
@@ -96,14 +105,15 @@ public class RegistryDecompressor
       double[] jointStateArray = buffer.getJointStates();
       if (jointStateArray.length > 0)
       {
-         DoubleBuffer jointStateBuffer = DoubleBuffer.wrap(jointStateArray);
+         System.arraycopy(jointStateArray, 0, jointStateData, 0, jointStateArray.length);
+         jointStateDoubleBuffer.rewind();
          for (int i = 0; i < jointStates.size(); i++)
          {
-            jointStates.get(i).update(jointStateBuffer);
+            jointStates.get(i).update(jointStateDoubleBuffer);
          }
          for (int i = 0; i < cachedJointStateValues.length; i++)
          {
-            cachedJointStateValues[i] = Double.doubleToLongBits(jointStateArray[i]);
+            cachedJointStateValues[i] = Double.doubleToLongBits(jointStateData[i]);
          }
       }
    }

--- a/src/main/java/us/ihmc/robotDataLogger/dataBuffers/RegistryDecompressor.java
+++ b/src/main/java/us/ihmc/robotDataLogger/dataBuffers/RegistryDecompressor.java
@@ -103,9 +103,10 @@ public class RegistryDecompressor
       }
 
       double[] jointStateArray = buffer.getJointStates();
-      if (jointStateArray.length > 0)
+      int jointStateCount = buffer.getJointStateCount();
+      if (jointStateCount > 0)
       {
-         System.arraycopy(jointStateArray, 0, jointStateData, 0, jointStateArray.length);
+         System.arraycopy(jointStateArray, 0, jointStateData, 0, jointStateCount);
          jointStateDoubleBuffer.rewind();
          for (int i = 0; i < jointStates.size(); i++)
          {

--- a/src/main/java/us/ihmc/robotDataLogger/dataBuffers/RegistryReceiveBuffer.java
+++ b/src/main/java/us/ihmc/robotDataLogger/dataBuffers/RegistryReceiveBuffer.java
@@ -5,12 +5,16 @@ import java.util.Arrays;
 
 public class RegistryReceiveBuffer extends RegistryBuffer
 {
-
-   private final long receivedTimestamp;
+   private long receivedTimestamp;
    private ByteBuffer compressedVariableDataBuffer;
    private double[] jointStates;
 
    public RegistryReceiveBuffer(long receivedTimestamp)
+   {
+      this.receivedTimestamp = receivedTimestamp;
+   }
+
+   public void setReceivedTimestamp(long receivedTimestamp)
    {
       this.receivedTimestamp = receivedTimestamp;
    }
@@ -22,13 +26,16 @@ public class RegistryReceiveBuffer extends RegistryBuffer
 
    public ByteBuffer allocateBuffer(int size)
    {
-      compressedVariableDataBuffer = ByteBuffer.allocate(size);
+      if (compressedVariableDataBuffer == null || compressedVariableDataBuffer.capacity() < size)
+         compressedVariableDataBuffer = ByteBuffer.allocate(size);
+      compressedVariableDataBuffer.clear();
       return compressedVariableDataBuffer;
    }
 
    public double[] allocateStates(int stateLength)
    {
-      jointStates = new double[stateLength];
+      if (jointStates == null || jointStates.length < stateLength)
+         jointStates = new double[stateLength];
       return jointStates;
    }
 

--- a/src/main/java/us/ihmc/robotDataLogger/dataBuffers/RegistryReceiveBuffer.java
+++ b/src/main/java/us/ihmc/robotDataLogger/dataBuffers/RegistryReceiveBuffer.java
@@ -8,6 +8,7 @@ public class RegistryReceiveBuffer extends RegistryBuffer
    private long receivedTimestamp;
    private ByteBuffer compressedVariableDataBuffer;
    private double[] jointStates;
+   private int jointStateCount = 0;
 
    public RegistryReceiveBuffer(long receivedTimestamp)
    {
@@ -34,9 +35,15 @@ public class RegistryReceiveBuffer extends RegistryBuffer
 
    public double[] allocateStates(int stateLength)
    {
+      jointStateCount = stateLength;
       if (jointStates == null || jointStates.length < stateLength)
          jointStates = new double[stateLength];
       return jointStates;
+   }
+
+   public int getJointStateCount()
+   {
+      return jointStateCount;
    }
 
    public double[] getJointStates()

--- a/src/main/java/us/ihmc/robotDataLogger/logger/YoVariableLoggerListener.java
+++ b/src/main/java/us/ihmc/robotDataLogger/logger/YoVariableLoggerListener.java
@@ -39,12 +39,12 @@ public class YoVariableLoggerListener implements YoVariablesUpdatedListener
     */
    private static final int TICKS_WITHOUT_DATA_BEFORE_SHUTDOWN = 5000;
    /**
-    * Create a buffer ring of 8 buffers. This keeps data in case the logger is slow.
+    * Create a buffer ring of 8 buffers. This keeps data in case the logger is slow. This is really needed because of garbage collection on the old logging machine
     */
-   private static final int BATCH_RING_BUFFER_SIZE = 8;
+   private static final int BATCH_RING_BUFFER_SIZE = 12;
 
    private static final int FLUSH_EVERY_N_PACKETS = 250;
-   private static final int COMPRESSION_BATCH_SIZE = 10;
+   private static final int COMPRESSION_BATCH_SIZE = 25;
    private static final int ZSTD_COMPRESSION_LEVEL = 1;
    public static final long STATUS_PACKET_RATE = Conversions.secondsToNanoseconds(5.0);
    private static final long VIDEO_RECORDING_TIMEOUT = Conversions.secondsToNanoseconds(1.0);

--- a/src/main/java/us/ihmc/robotDataLogger/websocket/client/WebSocketDataServerClientHandler.java
+++ b/src/main/java/us/ihmc/robotDataLogger/websocket/client/WebSocketDataServerClientHandler.java
@@ -111,7 +111,8 @@ public class WebSocketDataServerClientHandler extends SimpleChannelInboundHandle
       }
       else if (frame instanceof BinaryWebSocketFrame)
       {
-         RegistryReceiveBuffer buffer = new RegistryReceiveBuffer(System.nanoTime());
+         RegistryReceiveBuffer buffer = consumer.acquire();
+         buffer.setReceivedTimestamp(System.nanoTime());
          payload.getData().clear();
          payload.getData().limit(frame.content().readableBytes());
          frame.content().readBytes(payload.getData());


### PR DESCRIPTION
The images below were taken during the following experiment:
1. Controller was started
2. Logger was started
3. YourKit was attached to logger to view garbage collection
4. Ran for 2 minutes to see garbage collection times
We seem to use 4GB of Memory when the logger is running on the branch
___
DEVELOP
<img width="1587" height="605" alt="image" src="https://github.com/user-attachments/assets/90762ff8-7f3b-4ad2-821c-a31edaecc119" />
___
BRANCH
<img width="1587" height="605" alt="image" src="https://github.com/user-attachments/assets/6fef0aaf-3b56-40cb-a3b7-ffed2fb297be" />


