### PR TITLE
Expose a fast (keyframe-only) variant of MagewellDemuxer.seekToPTS

### DIFF
--- a/src/main/java/us/ihmc/robotDataLogger/logger/MagewellDemuxer.java
+++ b/src/main/java/us/ihmc/robotDataLogger/logger/MagewellDemuxer.java
@@ -50,9 +50,30 @@ public class MagewellDemuxer
 
     public void seekToPTS(long videoTimestamp)
     {
+        seekToPTS(videoTimestamp, false);
+    }
+
+    /**
+     * Seeks the underlying grabber to {@code videoTimestamp}.
+     * <p>
+     * When {@code fast} is {@code false}, this matches the historical behavior: the grabber decodes
+     * forward from the nearest preceding keyframe up to the exact target PTS, so the next
+     * {@link #getNextFrame()} call returns the frame at or just past the target.
+     * </p>
+     * <p>
+     * When {@code fast} is {@code true}, the grabber only seeks to the nearest preceding keyframe
+     * and does not decode forward to the target. The caller is then responsible for decoding
+     * forward via {@link #getNextFrame()} until reaching the desired PTS. This trades exact
+     * landing for substantially lower seek latency, which is useful when many seeks are issued in
+     * rapid succession (e.g. while a user is dragging a scrubber slider) and the caller is willing
+     * to display an intermediate frame.
+     * </p>
+     */
+    public void seekToPTS(long videoTimestamp, boolean fast)
+    {
         try
         {
-            grabber.setTimestamp(videoTimestamp);
+            grabber.setTimestamp(videoTimestamp, fast);
         }
         catch (FFmpegFrameGrabber.Exception e)
         {


### PR DESCRIPTION
## Summary

The current `MagewellDemuxer.seekToPTS(long)` delegates to `FFmpegFrameGrabber.setTimestamp(long)`, which decodes forward from the nearest preceding keyframe to the exact target PTS. For typical Magewell H.264 GOPs (1-2 s) this can take ~100-300 ms per seek, which is noticeable when the user drags a scrubber slider and many seeks are issued in rapid succession.

This PR adds an overload `seekToPTS(long, boolean fast)` that forwards the `fast` flag to `FFmpegFrameGrabber.setTimestamp(long, boolean)`. When `fast=true` the grabber stops at the nearest preceding keyframe and does not decode forward; the caller is then responsible for decoding forward to the desired PTS via `getNextFrame()` if exact landing is needed.

## Backward compatibility

The single-argument `seekToPTS(long)` overload is preserved and now delegates to the new overload with `fast=false`. Existing callers see identical behavior.

## Motivation

We are using this in [simulation-construction-set-2](https://github.com/ihmcrobotics/simulation-construction-set-2) to keep the scrubber UI responsive while the user is mid-drag: while a newer scrub request is already pending, the in-flight read uses the fast seek and displays the post-seek keyframe instead of paying the full GOP-decode cost. Once the user stops scrubbing, the final read still uses the precise (default) variant and lands on the exact frame.

## Testing

- `./gradlew compileJava` passes.
- The single-argument overload is behaviorally unchanged (it now calls the new two-argument overload with `false`).
