### PR TITLE
Await Netty shutdown, daemonize YoVar helper threads

### DIFF
--- a/src/main/java/us/ihmc/robotDataLogger/websocket/server/WebsocketDataBroadcaster.java
+++ b/src/main/java/us/ihmc/robotDataLogger/websocket/server/WebsocketDataBroadcaster.java
@@ -139,6 +139,7 @@ class WebsocketDataBroadcaster implements ChannelFutureListener
       private TimestampPublishingThread()
       {
          super(TimestampPublishingThread.class.getSimpleName());
+         setDaemon(true);
       }
 
       @Override

--- a/src/main/java/us/ihmc/robotDataLogger/websocket/server/WebsocketDataProducer.java
+++ b/src/main/java/us/ihmc/robotDataLogger/websocket/server/WebsocketDataProducer.java
@@ -89,10 +89,10 @@ public class WebsocketDataProducer implements DataProducer
             }
 
             if (bossGroup != null)
-               bossGroup.shutdownGracefully();
+               bossGroup.shutdownGracefully().syncUninterruptibly();
 
             if (workerGroup != null)
-               workerGroup.shutdownGracefully();
+               workerGroup.shutdownGracefully().syncUninterruptibly();
          }
          catch (InterruptedException e)
          {

--- a/src/main/java/us/ihmc/robotDataLogger/websocket/server/discovery/DataServerLocationBroadcastSender.java
+++ b/src/main/java/us/ihmc/robotDataLogger/websocket/server/discovery/DataServerLocationBroadcastSender.java
@@ -32,6 +32,7 @@ public class DataServerLocationBroadcastSender extends DataServerLocationBroadca
       }
 
       internalThread = new Thread(this::run, getClass().getSimpleName());
+      internalThread.setDaemon(true);
    }
 
    public void start()


### PR DESCRIPTION
YoVariableServer teardown was returning before Netty event loops finished, and timestamp/broadcast helper threads were non-daemon, so apps (e.g. MuJoCo behavior facilitator) could hang after close.

`WebsocketDataProducer.remove()` now awaits `shutdownGracefully()`, and the timestamp publisher / discovery broadcast threads are daemon so they cannot keep the JVM alive if stop is raced.