### PR TITLE
Feature/log handshake as binary

### DIFF
--- a/src/main/java/us/ihmc/robotDataLogger/handshake/IDLYoVariableHandshakeParser.java
+++ b/src/main/java/us/ihmc/robotDataLogger/handshake/IDLYoVariableHandshakeParser.java
@@ -22,6 +22,7 @@ import logger_msgs.YoVariableDefinition;
 import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.euclid.referenceFrame.tools.ReferenceFrameTools;
 import us.ihmc.euclid.transform.RigidBodyTransform;
+import us.ihmc.fastddsjava.cdr.CDRBuffer;
 import us.ihmc.fastddsjava.cdr.idl.IDLObjectSequence;
 import us.ihmc.idl.serializers.extra.ROS2YAMLSerializer;
 import us.ihmc.robotDataLogger.jointState.JointState;
@@ -57,6 +58,7 @@ import java.util.List;
  */
 public class IDLYoVariableHandshakeParser extends YoVariableHandshakeParser
 {
+   private final byte handshakeFileType;
    private final ROS2YAMLSerializer<Handshake> serializer;
 
    private TIntIntHashMap variableOffsets = new TIntIntHashMap();
@@ -64,7 +66,8 @@ public class IDLYoVariableHandshakeParser extends YoVariableHandshakeParser
    public IDLYoVariableHandshakeParser(HandshakeFileType type)
    {
       super();
-      switch (type.getType())
+      handshakeFileType = type.getType();
+      switch (handshakeFileType)
       {
          case HandshakeFileType.IDL_YAML:
             serializer = new ROS2YAMLSerializer<>(Handshake.class);
@@ -90,15 +93,32 @@ public class IDLYoVariableHandshakeParser extends YoVariableHandshakeParser
    @Override
    public void parseFrom(byte[] data) throws IOException
    {
-      if (serializer == null)
+      Handshake handshake;
+
+      if (handshakeFileType == HandshakeFileType.IDL_CDR)
       {
-         throw new RuntimeException();
+         CDRBuffer cdrBuffer = new CDRBuffer();
+         cdrBuffer.ensureRemainingCapacity(data.length);
+         cdrBuffer.getBufferUnsafe().put(data);
+         cdrBuffer.rewind();
+         cdrBuffer.readPayloadHeader();
+
+         handshake = new Handshake();
+         handshake.deserialize(cdrBuffer);
       }
-      Handshake handshake = serializer.deserialize(data);
-      if (handshake == null)
+      else
       {
-         throw new IOException("Failed to deserialize handshake YAML");
+         if (serializer == null)
+         {
+            throw new RuntimeException();
+         }
+         handshake = serializer.deserialize(data);
+         if (handshake == null)
+         {
+            throw new IOException("Failed to deserialize handshake YAML");
+         }
       }
+
       parseFrom(handshake);
    }
 

--- a/src/main/java/us/ihmc/robotDataLogger/logger/YoVariableLoggerListener.java
+++ b/src/main/java/us/ihmc/robotDataLogger/logger/YoVariableLoggerListener.java
@@ -8,6 +8,7 @@ import logger_msgs.Handshake;
 import logger_msgs.HandshakeFileType;
 import us.ihmc.commons.Conversions;
 import us.ihmc.commons.MathTools;
+import us.ihmc.fastddsjava.cdr.CDRBuffer;
 import us.ihmc.idl.serializers.extra.ROS2YAMLSerializer;
 import us.ihmc.log.LogTools;
 import us.ihmc.robotDataLogger.CameraSettingsLoader;
@@ -55,8 +56,15 @@ public class YoVariableLoggerListener implements YoVariablesUpdatedListener
    public static final long STATUS_PACKET_RATE = Conversions.secondsToNanoseconds(5.0);
    private static final long VIDEO_RECORDING_TIMEOUT = Conversions.secondsToNanoseconds(1.0);
 
+   /**
+    * Format the handshake file is written/read in. Switching this back to {@link HandshakeFileType#IDL_YAML} is
+    * sufficient on its own: the handshake filename and the write logic in {@link #logHandshake} both key off this
+    * constant, so nothing else needs to change.
+    */
+   private static final byte HANDSHAKE_FILE_TYPE = HandshakeFileType.IDL_CDR;
+
    public static final String propertyFile = propertyFileNameBuilder(0);
-   private static final String handshakeFilename = "handshake.yaml";
+   private static final String handshakeFilename = HANDSHAKE_FILE_TYPE == HandshakeFileType.IDL_CDR ? "handshake.cdr" : "handshake.yaml";
    private static final String dataFilename = "robotData.bsz";
    private static final String modelFilename = "model.sdf";
    private static final String modelResourceBundle = "resources.zip";
@@ -161,7 +169,7 @@ public class YoVariableLoggerListener implements YoVariablesUpdatedListener
       logProperties.getVariables().setCompressionBatchSize(COMPRESSION_BATCH_SIZE);
       logProperties.getVariables().setCompressionType("zstd");
       logProperties.getVariables().setIndex(indexFilename);
-      logProperties.getVariables().setHandshakeFileType(HandshakeFileType.IDL_YAML);
+      logProperties.getVariables().setHandshakeFileType(HANDSHAKE_FILE_TYPE);
 
       logProperties.setName(request.getNameAsString());
       logProperties.setTimestamp(timestamp);
@@ -210,8 +218,26 @@ public class YoVariableLoggerListener implements YoVariablesUpdatedListener
       File handshakeFile = new File(tempDirectory, handshakeFilename);
       try
       {
-         ROS2YAMLSerializer<Handshake> serializer = new ROS2YAMLSerializer<>(Handshake.class);
-         serializer.serialize(handshakeFile, handshake.getHandshake());
+         if (HANDSHAKE_FILE_TYPE == HandshakeFileType.IDL_CDR)
+         {
+            Handshake handshakeMessage = handshake.getHandshake();
+            CDRBuffer cdrBuffer = new CDRBuffer();
+            cdrBuffer.ensureRemainingCapacity(handshakeMessage.calculateSizeBytes(0) + 1024);
+            cdrBuffer.writePayloadHeader();
+            handshakeMessage.serialize(cdrBuffer);
+
+            ByteBuffer serializedBuffer = cdrBuffer.getBufferUnsafe();
+            serializedBuffer.flip();
+            try (FileChannel handshakeChannel = new FileOutputStream(handshakeFile).getChannel())
+            {
+               handshakeChannel.write(serializedBuffer);
+            }
+         }
+         else
+         {
+            ROS2YAMLSerializer<Handshake> serializer = new ROS2YAMLSerializer<>(Handshake.class);
+            serializer.serialize(handshakeFile, handshake.getHandshake());
+         }
       }
       catch (IOException e)
       {

--- a/src/main/java/us/ihmc/robotDataLogger/logger/YoVariableLoggerListener.java
+++ b/src/main/java/us/ihmc/robotDataLogger/logger/YoVariableLoggerListener.java
@@ -56,11 +56,6 @@ public class YoVariableLoggerListener implements YoVariablesUpdatedListener
    public static final long STATUS_PACKET_RATE = Conversions.secondsToNanoseconds(5.0);
    private static final long VIDEO_RECORDING_TIMEOUT = Conversions.secondsToNanoseconds(1.0);
 
-   /**
-    * Format the handshake file is written/read in. Switching this back to {@link HandshakeFileType#IDL_YAML} is
-    * sufficient on its own: the handshake filename and the write logic in {@link #logHandshake} both key off this
-    * constant, so nothing else needs to change.
-    */
    private static final byte HANDSHAKE_FILE_TYPE = HandshakeFileType.IDL_CDR;
 
    public static final String propertyFile = propertyFileNameBuilder(0);

--- a/src/main/java/us/ihmc/robotDataLogger/logger/YoVariableLoggerListener.java
+++ b/src/main/java/us/ihmc/robotDataLogger/logger/YoVariableLoggerListener.java
@@ -65,6 +65,8 @@ public class YoVariableLoggerListener implements YoVariablesUpdatedListener
 
    public static final String propertyFile = propertyFileNameBuilder(0);
    private static final String handshakeFilename = HANDSHAKE_FILE_TYPE == HandshakeFileType.IDL_CDR ? "handshake.cdr" : "handshake.yaml";
+   /** Human-readable copy of the handshake, written alongside {@link #handshakeFilename} when that file is binary. */
+   private static final String handshakeYamlFilename = "handshake.yaml";
    private static final String dataFilename = "robotData.bsz";
    private static final String modelFilename = "model.sdf";
    private static final String modelResourceBundle = "resources.zip";
@@ -232,6 +234,10 @@ public class YoVariableLoggerListener implements YoVariablesUpdatedListener
             {
                handshakeChannel.write(serializedBuffer);
             }
+
+            // Also drop a human-readable copy next to the binary handshake used for fast log loading.
+            ROS2YAMLSerializer<Handshake> yamlSerializer = new ROS2YAMLSerializer<>(Handshake.class);
+            yamlSerializer.serialize(new File(tempDirectory, handshakeYamlFilename), handshakeMessage);
          }
          else
          {
@@ -523,6 +529,13 @@ public class YoVariableLoggerListener implements YoVariablesUpdatedListener
          {
             LogTools.info("Deleting handshake file");
             handshakeFile.delete();
+         }
+
+         File handshakeYamlFile = new File(tempDirectory, handshakeYamlFilename);
+         if (handshakeYamlFile.exists())
+         {
+            LogTools.info("Deleting handshake yaml file");
+            handshakeYamlFile.delete();
          }
 
          File properties = new File(tempDirectory, propertyFile);


### PR DESCRIPTION
Added the file handshake to be saves as a binary file. This will make loading logs much faster as parsing a yaml takes time, and parsing a binary is much quicker.